### PR TITLE
Inject jetty component into request map

### DIFF
--- a/src/ring/component/jetty.clj
+++ b/src/ring/component/jetty.clj
@@ -11,7 +11,7 @@
       component
       (let [options (-> component (dissoc :app) (assoc :join? false))
             handler (atom (delay (:handler app)))
-            server  (jetty/run-jetty (fn [req] (@@handler req)) options)]
+            server  (jetty/run-jetty (fn [req] (@@handler (assoc req :component component))) options)]
         (assoc component
                :server  server
                :handler handler))))

--- a/test/ring/component/dependencies_test.clj
+++ b/test/ring/component/dependencies_test.clj
@@ -1,0 +1,30 @@
+(ns ring.component.dependencies-test
+  (:require [clojure.test :refer :all]
+            [ring.component.jetty :refer [jetty-server]]
+            [com.stuartsierra.component :as component]
+            [clj-http.client :as http]))
+
+(defn handler-fn [req]
+  {:status 200
+   :headers {}
+   :body (-> req :component :fake-db :data)})
+
+(defrecord FakeDB [data]
+  component/Lifecycle
+  (start [this] this)
+  (stop [this] this))
+
+(deftest component-dependencies-access
+  (let [test-system (component/system-map
+                     :fake-db (->FakeDB "some data")
+                     :http (component/using
+                            (jetty-server {:app {:handler handler-fn} :port 3401})
+                            [:fake-db]))
+        system (component/start test-system)]
+    (try
+      (let [response (http/get "http://127.0.0.1:3401")]
+        (is (= (:body response) "some data")))
+      (catch Exception e
+        (component/stop system))
+      (finally
+        (component/stop system)))))


### PR DESCRIPTION
This injects current component into the request map - thus exposing web server component's dependencies to the request handler. My understanding is that component ensures that dependencies are started before the component which depends on them.

For minimal use cases creating a handler component might be a bit too much. 
Not sure if this approach is the best but for a case where handler fn depends on one component (like a connection pool) all seems to be working fine.

Let me know what you think 👍 